### PR TITLE
added symlink for jwsacruncher

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,7 +87,9 @@ RUN R CMD javareconf -e && \
     rm -rf /tmp/downloaded_packages/ /tmp/*.rds && \
     # Doesn t work with Java11 - use a custom one
     #curl --silent -L -o- https://github.com/jdemetra/jwsacruncher/releases/download/v2.2.3/jwsacruncher-2.2.3-bin.zip | bsdtar -xvf- -C /opt && \
-    unzip /tmp/jwsacruncher-2.2.4.zip -d /opt && fix-permissions /opt/jwsacruncher-2.2.4 && rm -f /tmp/jwsacruncher-2.2.4.zip
+    unzip /tmp/jwsacruncher-2.2.4.zip -d /opt && fix-permissions /opt/jwsacruncher-2.2.4 && rm -f /tmp/jwsacruncher-2.2.4.zip && \
+    # Create a symlink at /usr/bin so users can call jwsacruncher from anywhere
+    ln -s /opt/jwsacruncher-2.2.4/bin/jwsacruncher /usr/bin/jwsacruncher
 
 USER $NB_UID
 


### PR DESCRIPTION
users should be able to call jwsacruncher from anywhere, and so adding it to /usr/bin allows that.