### PR TITLE
Let users be able to show/hide hidden files

### DIFF
--- a/docker/jupyter_notebook_extra_config.py
+++ b/docker/jupyter_notebook_extra_config.py
@@ -9,3 +9,6 @@ c.Application.log_level = 'WARN'
 
 # Allow deleting non-empty directories from the file browser
 c.FileContentsManager.always_delete_dir = True
+
+# Allow users to toggle show/hide hidden files
+c.ContentsManager.allow_hidden = True


### PR DESCRIPTION
According to [this page](https://github.com/jupyterlab/jupyterlab/issues/2049) the following flag will enable a menu item to let users show or hide hidden files, as demonstrated here:

![Demo](https://user-images.githubusercontent.com/42204205/128495305-fb0dde3f-2a57-42ae-8ac4-66a2b5920882.gif)
