### PR TITLE
Set env variable PIP_REQUIRE_VIRTUALENV=true

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -206,4 +206,7 @@ RUN cat /tmp/jupyter_notebook_extra_config.py >> /etc/jupyter/jupyter_notebook_c
     chmod g-w /etc/jupyter/*.py && \
     rm -f /tmp/jupyter_notebook_extra_config.py
 
+# User will not be able to install packages outside of a virtual environment
+RUN export PIP_REQUIRE_VIRTUALENV=true
+
 USER $NB_UID


### PR DESCRIPTION
Moved here from: https://github.com/statisticsnorway/jupyterhub-onprem/blob/main/docker/jupyterlab/bashrc.felles

Stops users from globally installing packages with pip, for more information see:
https://docs.python-guide.org/dev/pip-virtualenv/