### PR TITLE
Use ENV instead of RUN export

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -208,6 +208,6 @@ RUN cat /tmp/jupyter_notebook_extra_config.py >> /etc/jupyter/jupyter_notebook_c
     rm -f /tmp/jupyter_notebook_extra_config.py
 
 # User will not be able to install packages outside of a virtual environment
-RUN export PIP_REQUIRE_VIRTUALENV=true
+ENV PIP_REQUIRE_VIRTUALENV=true
 
 USER $NB_UID


### PR DESCRIPTION
Export won't persist across images, using ENV should fix the problem.

https://stackoverflow.com/questions/33379393/docker-env-vs-run-export