### PR TITLE
Move PIP_REQUIRE_VIRTUALENV to $HOME/.bashrc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -207,4 +207,7 @@ RUN cat /tmp/jupyter_notebook_extra_config.py >> /etc/jupyter/jupyter_notebook_c
     chmod g-w /etc/jupyter/*.py && \
     rm -f /tmp/jupyter_notebook_extra_config.py
 
+# User will not be able to install packages outside of a virtual environment
+RUN echo export PIP_REQUIRE_VIRTUALENV=true >> $HOME/.bashrc
+
 USER $NB_UID

--- a/docker/common-bashrc
+++ b/docker/common-bashrc
@@ -118,5 +118,3 @@ if ! shopt -oq posix; then
   fi
 fi
 eval "$(command conda shell.bash hook 2> /dev/null)"
-
-# User will not be able to install packages outside of a virtual environment

--- a/docker/common-bashrc
+++ b/docker/common-bashrc
@@ -120,4 +120,3 @@ fi
 eval "$(command conda shell.bash hook 2> /dev/null)"
 
 # User will not be able to install packages outside of a virtual environment
-export PIP_REQUIRE_VIRTUALENV=true


### PR DESCRIPTION
Ensures PIP_REQUIRE_VIRTUALENV persists across images. 