### PR TITLE
Temporarily disable ipyaggrid since it doesn't work

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -131,8 +131,9 @@ RUN echo "**** install jupyterlab-git ****" && \
     python3 -m pip install python-language-server[all] && \
     echo "**** install ipysheet ****" && \
     python3 -m pip install ipysheet && \
-    echo "**** install ipyaggrid ****" && \
-    python3 -m pip install ipyaggrid && \
+    #echo "**** install ipyaggrid ****" && \
+    #showstopper: https://github.com/jupyterlab/jupyterlab/issues/8176
+    #python3 -m pip install ipyaggrid && \
     #echo "**** install qgrid ****" && \
     #showstopper: https://github.com/quantopian/qgrid/issues/350
     #python3 -m pip install qgrid2 && \


### PR DESCRIPTION
The logs are filled with this error:

[W 2022-11-03 09:47:19.263 SingleUserLabApp log:186] 404 GET /user/kons-skaar@ssb.no/lab/extensions/ipyaggrid/static/remoteEntry.a46b34032dbf77d77343.js (kons-skaar@ssb.no@::ffff:127.0.0.6) 4.02ms

And it doesn't seem to work properly on Jupyterlab anyway (https://github.com/jupyterlab/jupyterlab/issues/8176)