### PR TITLE
Remove Sympy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,6 +148,8 @@ RUN echo "**** install jupyterlab-git ****" && \
     #python3 -m pip install --upgrade lckr-jupyterlab-variableinspector && \
     echo "**** uninstall IPython Parallels (comes default with dockerhub image)  ****" && \
     python3 -m pip uninstall -y ipyparallel && \
+    echo "**** uninstall Sympy and mpmath (comes default with dockerhub image)  ****" && \
+    python3 -m pip uninstall -y sympy mpmath && \
     # pipenv is used for keeping track of and loading the specific package dependencies of each repository
     # Together with with envkernel Jupyter users can create Jupyter kernels with a different environment.
     echo "**** install pipenv envkernel ****" && \


### PR DESCRIPTION
A dependency of Sympy has a vulnerability. Remove the
packages to resolve this.

-> Vulnerability found in mpmath version 1.2.1
   Vulnerability ID: 51549
   Affected spec: >=1.0.0,<=1.2.1
   ADVISORY: Mpmath v1.0.0 through v1.2.1 is affected by CVE-2021-29063: Regular Expression Denial of Service (ReDOS) vulnerability when the mpmathify function is called. The flaw has been fixed in the
   master branch of the Github repository.https://github.com/fredrik-johansson/mpmath/commit/46d44c3c8f3244017fe1eb102d564eb4ab8ef750
   CVE-2021-29063
   For more information, please visit https://pyup.io/v/51549/f17
